### PR TITLE
Remove default coloring on ConsoleAppender

### DIFF
--- a/src/__tests__/utils.spec.ts
+++ b/src/__tests__/utils.spec.ts
@@ -14,32 +14,57 @@ import {
 describe('test utils', () => {
   // noinspection DuplicatedCode
   it('formatLogLevel TRACE', () => {
-    expect(formatLogLevel(LogLevel.TRACE)).toBe('\x1B[90mTRACE\x1B[m');
+    expect(formatLogLevel(LogLevel.TRACE, true)).toBe('\x1B[90mTRACE\x1B[m');
   });
 
   it('formatLogLevel DEBUG', () => {
-    expect(formatLogLevel(LogLevel.DEBUG)).toBe('\x1B[37mDEBUG\x1B[m');
+    expect(formatLogLevel(LogLevel.DEBUG, true)).toBe('\x1B[37mDEBUG\x1B[m');
   });
 
   it('formatLogLevel INFO', () => {
-    expect(formatLogLevel(LogLevel.INFO)).toBe('\x1B[92mINFO\x1B[m');
+    expect(formatLogLevel(LogLevel.INFO, true)).toBe('\x1B[92mINFO\x1B[m');
   });
 
   // noinspection DuplicatedCode
   it('formatLogLevel WARN', () => {
-    expect(formatLogLevel(LogLevel.WARN)).toBe('\x1B[93mWARN\x1B[m');
+    expect(formatLogLevel(LogLevel.WARN, true)).toBe('\x1B[93mWARN\x1B[m');
   });
 
   it('formatLogLevel ERROR', () => {
-    expect(formatLogLevel(LogLevel.ERROR)).toBe('\x1B[91mERROR\x1B[m');
+    expect(formatLogLevel(LogLevel.ERROR, true)).toBe('\x1B[91mERROR\x1B[m');
   });
 
   it('formatLogLevel FATAL', () => {
-    expect(formatLogLevel(LogLevel.FATAL)).toBe('\x1B[95mFATAL\x1B[m');
+    expect(formatLogLevel(LogLevel.FATAL, true)).toBe('\x1B[95mFATAL\x1B[m');
   });
 
   it('formatLogLevel OFF', () => {
-    expect(formatLogLevel(LogLevel.OFF)).toBe('');
+    expect(formatLogLevel(LogLevel.OFF, true)).toBe('');
+  });
+
+  it('formatLogLevel TRACE without color', () => {
+    expect(formatLogLevel(LogLevel.TRACE)).toBe('TRACE');
+  });
+
+  it('formatLogLevel DEBUG without color', () => {
+    expect(formatLogLevel(LogLevel.DEBUG)).toBe('DEBUG');
+  });
+
+  it('formatLogLevel INFO without color', () => {
+    expect(formatLogLevel(LogLevel.INFO)).toBe('INFO');
+  });
+
+  // noinspection DuplicatedCode
+  it('formatLogLevel WARN without color', () => {
+    expect(formatLogLevel(LogLevel.WARN)).toBe('WARN');
+  });
+
+  it('formatLogLevel ERROR without color', () => {
+    expect(formatLogLevel(LogLevel.ERROR)).toBe('ERROR');
+  });
+
+  it('formatLogLevel FATAL without color', () => {
+    expect(formatLogLevel(LogLevel.FATAL)).toBe('FATAL');
   });
 
   it('formatISO8601', () => {
@@ -64,13 +89,23 @@ describe('test utils', () => {
   });
 
   it('formatPrefix with 5 chars log level', () => {
-    expect(formatPrefix(LogLevel.DEBUG, 'foo.bar'))
+    expect(formatPrefix(LogLevel.DEBUG, 'foo.bar', true))
       .toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}[+-]\d{2}:\d{2}\s.+?\s\[.{20}]:$/);
   });
 
   it('formatPrefix with 4 chars log level', () => {
-    expect(formatPrefix(LogLevel.INFO, 'foo.bar'))
+    expect(formatPrefix(LogLevel.INFO, 'foo.bar', true))
       .toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}[+-]\d{2}:\d{2}\s{2}.+?\s\[.{20}]:$/);
+  });
+
+  it('formatPrefix with 5 chars log level without color', () => {
+    expect(formatPrefix(LogLevel.DEBUG, 'foo.bar'))
+      .toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}[+-]\d{2}:\d{2}\sDEBUG\s\[.{20}]:$/);
+  });
+
+  it('formatPrefix with 4 chars log level without color', () => {
+    expect(formatPrefix(LogLevel.INFO, 'foo.bar'))
+      .toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}[+-]\d{2}:\d{2}\s{2}INFO\s\[.{20}]:$/);
   });
 
   describe('test getClassHierarchy', () => {

--- a/src/appender/ConsoleAppender.ts
+++ b/src/appender/ConsoleAppender.ts
@@ -58,7 +58,7 @@ export class ConsoleAppender extends AbstractBaseAppender {
           break;
       }
     }
-    const prefix = formatPrefix(event.level, event.loggerName);
+    const prefix = formatPrefix(event.level, event.loggerName, this.colored);
     if (typeof event.payload === 'function') {
       loggingMethod(prefix, event.payload());
     } else {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -208,24 +208,28 @@ export function formatISO8601(date: Date): string {
  *
  * @internal
  * @param level
+ * @param colored
  */
-export function formatLogLevel(level: LogLevel): string {
-  switch (level) {
-    case LogLevel.DEBUG:
-      return Ansi.gray('DEBUG');
-    case LogLevel.ERROR:
-      return Ansi.red('ERROR');
-    case LogLevel.FATAL:
-      return Ansi.magenta('FATAL');
-    case LogLevel.INFO:
-      return Ansi.green('INFO');
-    case LogLevel.TRACE:
-      return Ansi.darkGray('TRACE');
-    case LogLevel.WARN:
-      return Ansi.yellow('WARN');
-    default:
-      return '';
+export function formatLogLevel(level: LogLevel, colored: boolean = false): string {
+  if (colored) {
+    switch (level) {
+      case LogLevel.DEBUG:
+        return Ansi.gray('DEBUG');
+      case LogLevel.ERROR:
+        return Ansi.red('ERROR');
+      case LogLevel.FATAL:
+        return Ansi.magenta('FATAL');
+      case LogLevel.INFO:
+        return Ansi.green('INFO');
+      case LogLevel.TRACE:
+        return Ansi.darkGray('TRACE');
+      case LogLevel.WARN:
+        return Ansi.yellow('WARN');
+      default:
+        return '';
+    }
   }
+  return LogLevel[level];
 }
 
 /**
@@ -235,10 +239,16 @@ export function formatLogLevel(level: LogLevel): string {
  * @internal
  * @param level
  * @param name
+ * @param colored
  */
-export function formatPrefix(level: LogLevel, name: string): string {
-  const formattedLevel = formatLogLevel(level);
-  return `${formatISO8601(new Date())} ${formattedLevel.padStart(13, ' ')} [${truncateOrExtend(name, 20)}]:`;
+export function formatPrefix(level: LogLevel, name: string, colored: boolean = false): string {
+  let formattedLevel;
+  if (colored) {
+    formattedLevel = formatLogLevel(level, colored).padStart(13, ' ');
+  } else {
+    formattedLevel = formatLogLevel(level).padStart(5, ' ');
+  }
+  return `${formatISO8601(new Date())} ${formattedLevel} [${truncateOrExtend(name, 20)}]:`;
 }
 
 /**


### PR DESCRIPTION
The last commit message was wrong, it was no lint.

This change does not color the output with ConsoleAppender any more, because the ANSI solution ist not supported by most browsers.